### PR TITLE
Metaprogramming Helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.0.0)
+set(META_PROJECT_VERSION 0.1.0)
+set(META_PROJECT_NAME cpp)
+project(${META_PROJECT_NAME})
+
+add_subdirectory(src/meta)

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.0)
+project(meta)
+
+enable_testing()
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+
+include_directories (${Boost_INCLUDE_DIRS})
+
+include_directories (${CMAKE_SOURCE_DIR})
+
+set(INC
+  inc/${PROJECT_NAME}/detector.hpp
+  inc/${PROJECT_NAME}/devoid.hpp
+  inc/${PROJECT_NAME}/enable_if.hpp
+  inc/${PROJECT_NAME}/identity.hpp
+  inc/${PROJECT_NAME}/none_such.hpp
+  inc/${PROJECT_NAME}/void_safe.hpp
+)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE inc/)
+target_link_libraries(${PROJECT_NAME} INTERFACE ${Boost_LIBRARIES})
+
+install(
+  TARGETS ${PROJECT_NAME} DESTINATION lib
+)
+
+install(FILES ${INC} DESTINATION inc)

--- a/src/meta/inc/meta/detector.hpp
+++ b/src/meta/inc/meta/detector.hpp
@@ -1,0 +1,100 @@
+/**
+ * Inspired from CppNow Talk by Marshall Clow, published to youtube on
+ * Jun 6, 2017
+ *
+ * Link: https://www.youtube.com/watch?v=U3jGdnRL3KI
+ */
+
+#ifndef NIL_SRC_META_INC_META_DETECTOR_HPP_
+#define NIL_SRC_META_INC_META_DETECTOR_HPP_
+
+#include "meta/identity.hpp"
+#include "meta/none_such.hpp"
+
+namespace nil {
+
+template <bool predicate, class RetType = void>
+using If = std::enable_if_t<predicate, RetType>;
+
+template <class... T>
+using if_all = If<std::conjunction<T...>::value>;
+
+template <class Default, class, template <class...> class, class...>
+struct detector : public std::false_type {
+  static constexpr auto value = std::false_type::value;
+  using type = Default;
+  operator bool() { return value; }
+};
+
+template <class Default, template <class...> class MetaFunc, class... Args>
+struct detector<Default, std::void_t<MetaFunc<Args...>>, MetaFunc, Args...>
+    : public std::true_type {
+  static constexpr auto value = std::true_type::value;
+  using type = MetaFunc<Args...>;
+  operator bool() { return value; }
+};
+
+template <template <class...> class MetaFunc, class... Args>
+using exists = detector<none_such, void, MetaFunc, Args...>;
+
+template <template <class...> class MetaFunc, class... Args>
+using exists_t = typename detector<none_such, void, MetaFunc, Args...>::type;
+
+template <template <class...> class MetaFunc, class... Args>
+inline constexpr auto exists_v = exists<MetaFunc, Args...>::value;
+
+template <template <class...> class MetaFunc, class... Args>
+using if_exists = std::enable_if_t<exists_v<MetaFunc, Args...>>;
+
+template <template <class...> class MetaFunc, class... Args>
+using if_not_exists = std::enable_if_t<not exists_v<MetaFunc, Args...>>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using is_exact = std::is_same<exists_t<MetaFunc, Args...>, ExpectedT>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+inline constexpr auto is_exact_v = is_exact<ExpectedT, MetaFunc, Args...>{};
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using if_exact = std::enable_if_t<is_exact_v<ExpectedT, MetaFunc, Args...>>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using if_not_exact =
+    std::enable_if_t<not is_exact_v<ExpectedT, MetaFunc, Args...>>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using exists_similar =
+    std::is_same<ExpectedT, std::decay_t<exists_t<MetaFunc, Args...>>>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+inline constexpr auto exists_similar_v =
+    exists_similar<ExpectedT, MetaFunc, Args...>{};
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using if_exists_similar = If<exists_similar_v<ExpectedT, MetaFunc, Args...>>;
+
+template <class ExpectedT, template <class...> class MetaFunc, class... Args>
+using if_not_exists_similar =
+    If<not exists_similar_v<ExpectedT, MetaFunc, Args...>>;
+
+template <class T, template <class> class... Ops>
+using all_exist = std::conjunction<exists_t<Ops, T>...>;
+
+template <class T, template <class> class... Ops>
+using any_exist = std::disjunction<exists_t<Ops, T>...>;
+
+template <class T, template <class> class... Ops>
+using all_not_exist = std::negation<any_exist<T, Ops...>>;
+
+template <class T, template <class> class... Ops>
+using if_all_exist = If<all_exist<T, Ops...>{}>;
+
+template <class T, template <class> class... Ops>
+using if_any_exist = If<any_exist<T, Ops...>{}>;
+
+template <class T, template <class> class... Ops>
+using if_all_not_exist = If<all_not_exist<T, Ops...>{}>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_DETECTOR_HPP_

--- a/src/meta/inc/meta/devoid.hpp
+++ b/src/meta/inc/meta/devoid.hpp
@@ -1,0 +1,28 @@
+#ifndef NIL_SRC_META_INC_META_DEVOID_HPP_
+#define NIL_SRC_META_INC_META_DEVOID_HPP_
+
+#include <type_traits>
+
+namespace nil {
+
+struct devoid {};
+
+/** trait to detect struct devoid */
+template <class T>
+using is_devoid = std::is_same<devoid, T>;
+
+/** convenience inline variable for devoid detection */
+template <class T>
+inline constexpr auto is_devoid_v = is_devoid<T>::value;
+
+/** convenience alias for SFINAE */
+template <class T>
+using if_devoid = std::enable_if_t<is_devoid_v<T>>;
+
+/** convenience alias for SFINAE */
+template <class T>
+using if_not_devoid = std::enable_if_t<not is_devoid_v<T>>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_DEVOID_HPP_

--- a/src/meta/inc/meta/enable_if.hpp
+++ b/src/meta/inc/meta/enable_if.hpp
@@ -1,0 +1,101 @@
+#ifndef NIL_SRC_META_INC_META_ENABLEIF_HPP_
+#define NIL_SRC_META_INC_META_ENABLEIF_HPP_
+
+#include <type_traits>
+#include <utility>
+
+#include "meta/detector.hpp"
+
+namespace nil {
+
+// more readible SFINAE, just wraps STL traits ---------------------------------
+
+template <class T, class U = void>
+using if_void = If<std::is_void_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_void = If<!std::is_void_v<T>, U>;
+
+template <class T, class U = void>
+using if_default_constructible = If<std::is_default_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_default_constructible = If<!std::is_default_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_copy_constructible = If<std::is_copy_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_copy_constructible = If<!std::is_copy_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_move_constructible = If<std::is_move_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_move_constructible = If<!std::is_move_constructible_v<T>, U>;
+
+template <class T, class U = void>
+using if_copy_assignable = If<std::is_copy_assignable_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_copy_assignable = If<!std::is_copy_assignable_v<T>, U>;
+
+template <class T, class U = void>
+using if_move_assignable = If<std::is_move_assignable_v<T>, U>;
+
+template <class T, class U = void>
+using if_not_move_assignable = If<!std::is_move_assignable_v<T>, U>;
+
+template <class T, class... Args>
+using if_constructible = If<std::is_constructible_v<T, Args...>>;
+
+template <class T, class... Args>
+using if_not_constructible = If<!std::is_constructible_v<T, Args...>>;
+
+template <class T, class U, class V = void>
+using if_assignable = If<std::is_assignable_v<T, U>, V>;
+
+template <class T, class U, class V = void>
+using if_not_assignable = If<!std::is_assignable_v<T, U>, V>;
+
+template <class T, class U, class V = void>
+using if_same = If<std::is_same_v<T, U>, V>;
+
+template <class T, class U, class V = void>
+using if_not_same = If<!std::is_same_v<T, U>, V>;
+
+template <class Fn, class... Args>
+using if_invocable = If<std::is_invocable_v<Fn, Args...>>;
+
+template <class Fn, class... Args>
+using if_not_invocable = If<!std::is_invocable_v<Fn, Args...>>;
+
+template <class R, class Fn, class... Args>
+using if_invocable_r = If<std::is_invocable_r_v<R, Fn, Args...>>;
+
+template <class R, class Fn, class... Args>
+using if_not_invocable_r = If<!std::is_invocable_r_v<R, Fn, Args...>>;
+
+// New traits, not in STL ------------------------------------------------------
+
+template <class T>
+using is_in_place = std::is_same<std::in_place_t, std::decay_t<T>>;
+
+template <class T>
+inline constexpr auto is_in_place_v = is_in_place<T>::value;
+
+template <class T, class U>
+using is_similar = std::is_same<std::decay_t<T>, std::decay_t<U>>;
+
+template <class T, class U>
+inline constexpr auto is_similar_v = is_similar<T, U>::value;
+
+template <class T, class U, class V = void>
+using if_similar = If<is_similar_v<T, U>, V>;
+
+template <class T, class U, class V = void>
+using if_not_similar = If<!is_similar_v<T, U>, V>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_ENABLEIF_HPP_

--- a/src/meta/inc/meta/identity.hpp
+++ b/src/meta/inc/meta/identity.hpp
@@ -1,0 +1,14 @@
+#ifndef NIL_SRC_META_INC_META_IDENTITY_HPP_
+#define NIL_SRC_META_INC_META_IDENTITY_HPP_
+
+namespace nil {
+
+/** holds @tparam under alias type */
+template <class T>
+struct identity {
+  using type = T;
+};
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_IDENTITY_HPP_

--- a/src/meta/inc/meta/none_such.hpp
+++ b/src/meta/inc/meta/none_such.hpp
@@ -1,0 +1,36 @@
+#ifndef NIL_SRC_META_INC_META_NONESUCH_HPP_
+#define NIL_SRC_META_INC_META_NONESUCH_HPP_
+
+#include <type_traits>
+
+namespace nil {
+
+struct none_such {
+  none_such() = delete;
+  none_such(const none_such&) = delete;
+  none_such(none_such&&) = delete;
+  none_such& operator=(const none_such&) = delete;
+  none_such& operator=(none_such&&) = delete;
+};
+
+struct MoveOnly {
+  MoveOnly() = default;
+  MoveOnly(const MoveOnly&) = delete;
+  MoveOnly& operator=(const MoveOnly&) = delete;
+  MoveOnly(MoveOnly&&) noexcept = default;
+  MoveOnly& operator=(MoveOnly&&) noexcept = default;
+};
+
+struct NonDefaultConstructible {
+  NonDefaultConstructible() = delete;
+  NonDefaultConstructible(int ii_) : ii{ii_} {}
+  NonDefaultConstructible(const NonDefaultConstructible&) = default;
+  NonDefaultConstructible& operator=(const NonDefaultConstructible&) = default;
+  NonDefaultConstructible(NonDefaultConstructible&&) = default;
+  NonDefaultConstructible& operator=(NonDefaultConstructible&&) = default;
+  int ii;
+};
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_NONESUCH_HPP_

--- a/src/meta/inc/meta/void_safe.hpp
+++ b/src/meta/inc/meta/void_safe.hpp
@@ -1,0 +1,14 @@
+#ifndef NIL_SRC_META_INC_META_VOIDSAFE_HPP_
+#define NIL_SRC_META_INC_META_VOIDSAFE_HPP_
+
+#include "meta/devoid.hpp"
+
+namespace nil {
+
+/** Either just @tparam T or devoid if T is void */
+template <class T>
+using void_safe = std::conditional_t<std::is_void_v<T>, devoid, T>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_META_INC_META_VOID_SAFE_HPP_


### PR DESCRIPTION
Changes:
- detection idiom impl
  - includes `exists`, `is_exact`, `exists_similar`, `exist_all`, `exists_any`
- convenience `if_x` and `if_not_x` aliases for sfinae on some `std` traits
- convenience `if_all` alias 
- `identity` type - stores template type, and helps with multiple arg deduction issues
- `void_safe` - either T or empty struct `devoid`, switched with `std::conditional`