### PR TITLE
Atomic - Thread-safe wrapper around any type T

### DIFF
--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -17,16 +17,7 @@ include_directories (${Boost_INCLUDE_DIRS})
 
 set(INC
   inc/${PROJECT_NAME}/atomic.hpp
-  inc/${PROJECT_NAME}/atomic_proxies.hpp
-  inc/${PROJECT_NAME}/atomic_rw.hpp
-  inc/${PROJECT_NAME}/atomic_rw_base.hpp
-  inc/${PROJECT_NAME}/container_base.hpp
-  inc/${PROJECT_NAME}/container_traits.hpp
-  inc/${PROJECT_NAME}/deque.hpp
-  inc/${PROJECT_NAME}/list.hpp
-  inc/${PROJECT_NAME}/optional.hpp
-  inc/${PROJECT_NAME}/optional_base.hpp
-  inc/${PROJECT_NAME}/vector.hpp
+  inc/${PROJECT_NAME}/atomic_base.hpp
 )
 
 add_library(${PROJECT_NAME} INTERFACE)

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.0)
+project(async)
+
+enable_testing()
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-pthread")
+
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+find_package(nil_cpp COMPONENTS meta)
+find_package(Threads REQUIRED)
+
+include_directories (${Boost_INCLUDE_DIRS})
+
+set(INC
+  inc/${PROJECT_NAME}/atomic.hpp
+  inc/${PROJECT_NAME}/atomic_proxies.hpp
+  inc/${PROJECT_NAME}/atomic_rw.hpp
+  inc/${PROJECT_NAME}/atomic_rw_base.hpp
+  inc/${PROJECT_NAME}/container_base.hpp
+  inc/${PROJECT_NAME}/container_traits.hpp
+  inc/${PROJECT_NAME}/deque.hpp
+  inc/${PROJECT_NAME}/list.hpp
+  inc/${PROJECT_NAME}/optional.hpp
+  inc/${PROJECT_NAME}/optional_base.hpp
+  inc/${PROJECT_NAME}/vector.hpp
+)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE inc/)
+target_link_libraries(${PROJECT_NAME} INTERFACE meta Threads::Threads)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(FILES ${INC} DESTINATION inc)
+
+function(add_boost_test test_name)
+  message(STATUS argn: ${ARGN})
+  message(STATUS ${test_name})
+  add_executable(${test_name} tests/${test_name}.cpp)
+  target_link_libraries(${test_name} ${Boost_LIBRARIES} ${PROJECT_NAME} ${ARGN})
+  add_test(${test_name}_test COMMAND ${test_name})
+endfunction()
+
+add_boost_test(container_traits_test)
+add_boost_test(container_test)
+add_boost_test(atomic_test)
+add_boost_test(atomic_rw_test)
+add_boost_test(optional_test)

--- a/src/async/inc/async/atomic.hpp
+++ b/src/async/inc/async/atomic.hpp
@@ -1,0 +1,20 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_ATOMIC_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_ATOMIC_HPP_
+
+#include <mutex>
+
+#include "async/atomic_base.hpp"
+
+namespace nil {
+
+/**
+ * Specialized for std::mutex with std::shared_lock. This is the expected
+ * way for this utility to be used, but the base version can be used direcly if
+ * using other mutex types (like boost)
+ */
+template <class T>
+using atomic = atomic_base<T, std::mutex, std::lock_guard>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_ATOMIC_HPP_

--- a/src/async/inc/async/atomic_base.hpp
+++ b/src/async/inc/async/atomic_base.hpp
@@ -1,0 +1,82 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_ATOMICBASE_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_ATOMICBASE_HPP_
+
+#include <functional>
+#include <meta/enable_if.hpp>
+
+namespace nil {
+
+/**
+ * Base class for atomic, templated on some T + mutex and lock types
+ *
+ * This class wraps any type with a mutex and ensures all operations on this
+ * class are thread-safe.
+ *
+ * In addition to the standard push and peek, apply takes any function, allowing
+ * you to perform complex operations while the mutex is locked
+ *
+ * @tparam T - any copyable type
+ * @tparam Mutex - a standard mutex, like std::mutex
+ * @tparam LockGuard - an RAII lock, like std::lock_guard
+ */
+template <class T, class Mutex, template <class> class LockGuard>
+class atomic_base {
+  static_assert(std::is_copy_constructible_v<T>, "T must be copyable");
+
+ public:
+  using value_type = T;
+  using mutex_type = Mutex;
+  using lock_type_t = LockGuard<Mutex>;
+
+  // constructors --------------------------------------------------------------
+
+  template <class U = T, if_default_constructible<U>* = nullptr>
+  constexpr atomic_base() {}
+
+  template <class... Args>
+  constexpr atomic_base(Args&&... args) : t_{std::forward<Args>(args)...} {}
+
+  // deleted copy and move constructors and assignment -------------------------
+
+  atomic_base(const atomic_base&) = delete;
+  atomic_base& operator=(const atomic_base&) = delete;
+  atomic_base(atomic_base&&) = delete;
+  atomic_base& operator=(atomic_base&&) = delete;
+
+  // get a copy of data --------------------------------------------------------
+
+  T peek() const {
+    lock_type_t lock(mutex_);
+    return t_;
+  }
+
+  // mutate data ---------------------------------------------------------------
+
+  template <class U = T, class = if_assignable<T, U&&>>
+  void push(U&& u) {
+    lock_type_t lock(mutex_);
+    t_ = std::forward<U>(u);
+  }
+
+  // execute arbitary function on data -----------------------------------------
+
+  template <class F>
+  auto apply(F&& f) const {
+    lock_type_t lock(mutex_);
+    return std::invoke(std::forward<F>(f), static_cast<const T&>(t_));
+  }
+
+  template <class F>
+  auto apply(F&& f) {
+    lock_type_t lock(mutex_);
+    return std::invoke(std::forward<F>(f), static_cast<T&>(t_));
+  }
+
+ private:
+  mutable mutex_type mutex_;
+  T t_;
+};
+
+}  // namespace nil
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_ATOMICBASE_HPP_

--- a/src/async/tests/atomic_test.cpp
+++ b/src/async/tests/atomic_test.cpp
@@ -1,0 +1,70 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE atomic_test
+
+#include "async/atomic.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <iostream>
+#include <numeric>
+
+using namespace nil;
+
+BOOST_AUTO_TEST_CASE(BasicTest) {
+  atomic<std::string> atomic_str{"hello"};
+  BOOST_CHECK_EQUAL(atomic_str.peek(), "hello");
+  BOOST_CHECK_EQUAL(atomic_str.peek(), "hello");
+
+  atomic_str.push("yo");
+  BOOST_CHECK_EQUAL(atomic_str.peek(), "yo");
+
+  const auto& const_atomic_str = atomic_str;
+  std::string str = "";
+  const_atomic_str.apply([&str](const auto& a_str) { str = a_str; });
+  BOOST_CHECK_EQUAL("yo", str);
+
+  str = const_atomic_str.apply(
+      [](const auto& a_str) { return a_str + std::string{"yo"}; });
+  BOOST_CHECK_EQUAL("yoyo", str);
+  BOOST_CHECK_EQUAL("yo", atomic_str.peek());
+
+  str = atomic_str.apply([](auto& a_str) {
+    a_str += std::string{"ho"};
+    return a_str;
+  });
+  BOOST_CHECK_EQUAL("yoho", str);
+  BOOST_CHECK_EQUAL("yoho", atomic_str.peek());
+}
+
+BOOST_AUTO_TEST_CASE(MultithreadedTest) {
+  nil::atomic<int> counter{0};
+  nil::atomic<std::vector<int>> atomic_vec;
+  const auto counter_max = 10000;
+
+  auto func = [&]() {
+    while (true) {
+      auto next_val = counter.apply([](auto& ii) {
+        ii++;
+        return ii;
+      });
+      if (next_val > counter_max) {
+        return;
+      }
+      atomic_vec.apply([&](auto& vec) { vec.push_back(next_val); });
+    }
+  };
+
+  auto f1 = std::async(std::launch::async, func);
+  auto f2 = std::async(std::launch::async, func);
+  auto f3 = std::async(std::launch::async, func);
+  auto f4 = std::async(std::launch::async, func);
+
+  f1.get();
+  f2.get();
+  f3.get();
+  f4.get();
+
+  auto vec = atomic_vec.peek();
+  BOOST_CHECK_EQUAL(std::accumulate(vec.cbegin(), vec.cend(), 0),
+                    counter_max * (counter_max + 1) / 2);
+}


### PR DESCRIPTION
Changes:
- `atomic_base`, a generic wrapper around any type that provides thread-safe only access to internal data
  - templated on mutex + lock, so you don't have to use STL
  - convenience alias `atomic` provided when working with STL
  - generic `apply` func for running multiple statements while locked