### PR TITLE
async::optional - an alternative to atomic when null-state is required

### DIFF
--- a/src/async/inc/async/optional.hpp
+++ b/src/async/inc/async/optional.hpp
@@ -1,0 +1,19 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_OPTIONAL_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_OPTIONAL_HPP_
+
+#include <optional>
+
+#include "async/optional_base.hpp"
+
+namespace nil::async {
+
+/**
+ * Partially specified alias if working with std::optional. This should be the
+ * prefered usage.
+ */
+template <class T>
+using optional = optional_base<T, std::optional, std::nullopt_t>;
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_OPTIONAL_HPP_

--- a/src/async/inc/async/optional_base.hpp
+++ b/src/async/inc/async/optional_base.hpp
@@ -1,0 +1,110 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_OPTIONALBASE_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_OPTIONALBASE_HPP_
+
+#include <functional>
+#include <meta/enable_if.hpp>
+#include <mutex>
+
+namespace nil::async {
+
+/**
+ * Similar to the atomic class but provides an additional null state for T
+ *
+ * @tparam T - any type, including move-only types
+ * @tparam OptT - the underlying optional type, like std::optional
+ * @tparam NullT - the null type for @tparam OptT, like std::nullopt_t
+ */
+template <class T, template <class> class OptT, class NullT>
+class optional_base {
+ public:
+  using value_type = T;
+  using opt_type = OptT<T>;
+  using null_type = NullT;
+
+ private:
+  mutable std::mutex mutex_;
+  opt_type t_{};
+
+ public:
+  // construct with null -------------------------------------------------------
+
+  constexpr optional_base() = default;
+  constexpr optional_base(null_type) {}
+
+  // construct with T ----------------------------------------------------------
+
+  /** std::in_place_t ensures variadic universal ref constructor isn't greedy */
+  template <class... Args, if_constructible<T, Args...>* = nullptr>
+  constexpr optional_base(std::in_place_t, Args&&... args)
+      : t_{std::in_place, std::forward<Args>(args)...} {}
+
+  // no copying/moving ---------------------------------------------------------
+
+  optional_base(const optional_base&) = delete;
+  optional_base& operator=(const optional_base&) = delete;
+  optional_base(optional_base&&) = delete;
+  optional_base& operator=(optional_base&&) = delete;
+
+  // inspect -------------------------------------------------------------------
+
+  /** only valid if T is copyable */
+  opt_type peek() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return t_;
+  }
+
+  // update --------------------------------------------------------------------
+
+  void push(const opt_type& opt_val) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    t_ = opt_val;
+  }
+
+  void push(opt_type&& opt_val) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    t_ = std::move(opt_val);
+  }
+
+  template <class U = T, class = if_assignable<T, U&&>>
+  void push(U&& u) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    t_ = {std::forward<U>(u)};
+  }
+
+  template <class... Args, if_constructible<T, Args...>* = nullptr>
+  void push(std::in_place_t, Args&&... args) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    t_ = {{std::forward<Args>(args)...}};
+  }
+
+  // remove and return ---------------------------------------------------------
+
+  template <class U = T, class = if_constructible<T, U&&>>
+  opt_type pop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!t_) {
+      return opt_type{};
+    }
+    auto temp = std::move(t_.value());
+    t_.reset();
+    return {std::move(temp)};
+  }
+
+  // arbitrary function --------------------------------------------------------
+
+  template <class F>
+  auto apply(F&& f) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return std::invoke(std::forward<F>(f), static_cast<const opt_type&>(t_));
+  }
+
+  template <class F>
+  auto apply(F&& f) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return std::invoke(std::forward<F>(f), static_cast<opt_type&>(t_));
+  }
+};
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_OPTIONALBASE_HPP_

--- a/src/async/tests/optional_test.cpp
+++ b/src/async/tests/optional_test.cpp
@@ -1,0 +1,134 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE optional_test
+
+#include "async/optional.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <iostream>
+#include <numeric>
+
+#include "async/atomic.hpp"
+
+using namespace nil;
+
+BOOST_AUTO_TEST_CASE(BasicTest) {
+  async::optional<std::string> async_optional{std::in_place, "hello"};
+  BOOST_CHECK_EQUAL(async_optional.peek().value(), "hello");
+  BOOST_CHECK_EQUAL(async_optional.peek().value(), "hello");
+
+  async_optional.push("yo");
+  BOOST_CHECK_EQUAL(async_optional.peek().value(), "yo");
+
+  const auto& const_atomic_str = async_optional;
+  std::string str = "";
+  const_atomic_str.apply([&str](const auto& a_str_opt) { str = (*a_str_opt); });
+  BOOST_CHECK_EQUAL("yo", str);
+
+  str = const_atomic_str.apply(
+      [](const auto& a_str_opt) { return (*a_str_opt) + std::string{"yo"}; });
+  BOOST_CHECK_EQUAL("yoyo", str);
+  BOOST_CHECK_EQUAL("yo", async_optional.peek().value());
+
+  str = async_optional.apply([](auto& a_str_opt) {
+    (*a_str_opt) += std::string{"ho"};
+    return *a_str_opt;
+  });
+  BOOST_CHECK_EQUAL("yoho", str);
+  BOOST_CHECK_EQUAL("yoho", async_optional.peek().value());
+}
+
+BOOST_AUTO_TEST_CASE(PushPopTest) {
+  async::optional<MoveOnly> async_opt{std::in_place};
+  BOOST_CHECK(async_opt.pop() != std::nullopt);
+  BOOST_CHECK(async_opt.pop() == std::nullopt);
+  BOOST_CHECK(async_opt.pop() == std::nullopt);
+  BOOST_CHECK(async_opt.pop() == std::nullopt);
+
+  async_opt.push(std::nullopt);
+  BOOST_CHECK(async_opt.pop() == std::nullopt);
+
+  async_opt.push(std::optional<MoveOnly>{});
+  BOOST_CHECK(async_opt.pop() == std::nullopt);
+
+  async_opt.push(std::optional<MoveOnly>{MoveOnly{}});
+  BOOST_CHECK(async_opt.pop() != std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(MultithreadedTest) {
+  nil::async::optional<int> counter{std::in_place, 0};
+  nil::async::optional<std::vector<int>> async_optional_vec{std::in_place};
+  const auto counter_max = 10000;
+
+  auto func = [&]() {
+    while (true) {
+      auto next_val = counter.apply([](auto& ii_opt) {
+        (*ii_opt)++;
+        return (*ii_opt);
+      });
+      if (next_val > counter_max) {
+        return;
+      }
+      async_optional_vec.apply(
+          [&](auto& vec_opt) { vec_opt->push_back(next_val); });
+    }
+  };
+
+  auto f1 = std::async(std::launch::async, func);
+  auto f2 = std::async(std::launch::async, func);
+  auto f3 = std::async(std::launch::async, func);
+  auto f4 = std::async(std::launch::async, func);
+
+  f1.get();
+  f2.get();
+  f3.get();
+  f4.get();
+
+  auto vec = async_optional_vec.peek().value();
+  BOOST_CHECK_EQUAL(std::accumulate(vec.cbegin(), vec.cend(), 0),
+                    counter_max * (counter_max + 1) / 2);
+}
+
+struct OptionalLikeNull {
+  constexpr OptionalLikeNull(int) {}
+};
+
+inline constexpr auto optional_like_null = OptionalLikeNull{0};
+
+template <class T>
+struct OptionalLike {
+  using value_type = T;
+  union {
+    T t_;
+    bool b_;
+  };
+
+  OptionalLike() {}
+  OptionalLike(OptionalLikeNull) {}
+
+  template <class... Args>
+  OptionalLike(std::in_place_t, Args&&...) {}
+
+  OptionalLike& operator=(OptionalLikeNull) {}
+
+  template <class U = T>
+  OptionalLike& operator=(U&&) {}
+
+  const T& value() const& { return t_; }
+  const T&& value() const&& { return t_; }
+  T& value() & { return t_; }
+  T&& value() && { return t_; }
+
+  void reset() const& {}
+
+  explicit operator bool() { return true; }
+};
+
+BOOST_AUTO_TEST_CASE(OptionalLikeTest) {
+  using OptType = async::optional_base<int, OptionalLike, OptionalLikeNull>;
+  OptType op;
+  op.peek();
+  op.pop();
+  op.push(optional_like_null);
+  op.apply([](const auto&) { return 5; });
+}


### PR DESCRIPTION
Changes:
- a new `async::optional` type
  - same as atomic, but with null state
  - works with non-copyable types
  - still has generic `apply` for multi-statement thread-safe functions