### PR TITLE
atomic_rw - an atomic class with reader-write symantics

### DIFF
--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -18,6 +18,9 @@ include_directories (${Boost_INCLUDE_DIRS})
 set(INC
   inc/${PROJECT_NAME}/atomic.hpp
   inc/${PROJECT_NAME}/atomic_base.hpp
+  inc/${PROJECT_NAME}/atomic_proxies.hpp
+  inc/${PROJECT_NAME}/atomic_rw.hpp
+  inc/${PROJECT_NAME}/atomic_rw_base.hpp
   inc/${PROJECT_NAME}/optional.hpp
   inc/${PROJECT_NAME}/optional_base.hpp
 )
@@ -39,3 +42,4 @@ endfunction()
 
 add_boost_test(atomic_test)
 add_boost_test(optional_test)
+add_boost_test(atomic_rw_test)

--- a/src/async/inc/async/atomic_rw.hpp
+++ b/src/async/inc/async/atomic_rw.hpp
@@ -1,0 +1,21 @@
+#ifndef NIL_SRC_THREADSAFE_INC_THREADSAFE_RWATOMIC_HPP_
+#define NIL_SRC_THREADSAFE_INC_THREADSAFE_RWATOMIC_HPP_
+
+#include <shared_mutex>
+
+#include "async/atomic_rw_base.hpp"
+
+namespace nil {
+
+/**
+ * Specialized for std::shared_mutex with std::shared_lock. This is the expected
+ * way for this utility to be used, but the base version can be used direcly if
+ * using other mutex types (like boost, or std::shared_timed_mutex)
+ */
+template <class T>
+using atomic_rw =
+    atomic_rw_base<T, std::shared_mutex, std::unique_lock, std::shared_lock>;
+
+}  // namespace nil
+
+#endif  // NIL_SRC_THREADSAFE_INC_THREADSAFE_RWATOMIC_HPP_

--- a/src/async/inc/async/atomic_rw_base.hpp
+++ b/src/async/inc/async/atomic_rw_base.hpp
@@ -1,3 +1,10 @@
+/**
+ * Concept is inspired by Louis Charles implementation of `Safe`:
+ * https://github.com/LouisCharlesC/safe
+ *
+ * Small tweaks to API, but the concept is quite similar
+ */
+
 #ifndef NIL_SRC_ASYNC_INC_ASYNC_ATOMICRWBASE_HPP_
 #define NIL_SRC_ASYNC_INC_ASYNC_ATOMICRWBASE_HPP_
 

--- a/src/async/inc/async/atomic_rw_base.hpp
+++ b/src/async/inc/async/atomic_rw_base.hpp
@@ -1,0 +1,88 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_ATOMICRWBASE_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_ATOMICRWBASE_HPP_
+
+#include <meta/enable_if.hpp>
+
+#include "async/atomic_rw_proxy.hpp"
+
+namespace nil {
+
+/**
+ * Wraps any type T with a reader-writer mutex. Provides read-only and write
+ * access to the underlying type.
+ *
+ * The read or write proxies hold their lock RAII style, and release it upon
+ * destruction.
+ *
+ * The provides terse, pointer-like symantics for reading. Writing requires a
+ * slightly more verbose function call to mark it as a more expensive operation
+ *
+ * @note calling write() twice from the same thread within the same scope will
+ * cause deadlock (or undefined behaviour)
+ *
+ * @tparam T - any copyable type
+ * @tparam SharedMutex - a reader-writer mutex, like std::shared_mutex
+ * @tparam WriteLock - an RAII unique lock, like std::unique_lock
+ * @tparam ReadLock - an RAII shared lock, like std::shared_lock
+ */
+template <class T,                           //
+          class SharedMutex,                 //
+          template <class> class WriteLock,  //
+          template <class> class ReadLock>
+class atomic_rw_base {
+  static_assert(std::is_copy_constructible_v<T>, "T must be copyable");
+
+ public:
+  using value_type = T;
+  using mutex_type = SharedMutex;
+  using write_lock = WriteLock<SharedMutex>;
+  using read_lock = ReadLock<SharedMutex>;
+  using read_proxy_t = atomic_r_proxy<T, mutex_type, ReadLock>;
+  using write_proxy_t = atomic_rw_proxy<T, mutex_type, WriteLock>;
+
+  // constructors --------------------------------------------------------------
+
+  template <class U = T, if_default_constructible<U>* = nullptr>
+  constexpr atomic_rw_base() {}
+
+  template <class... Args>
+  constexpr atomic_rw_base(Args&&... args) : t_{std::forward<Args>(args)...} {}
+
+  // deleted copy and move constructors and assignment -------------------------
+
+  atomic_rw_base(const atomic_rw_base&) = delete;
+  atomic_rw_base& operator=(const atomic_rw_base&) = delete;
+  atomic_rw_base(atomic_rw_base&&) = delete;
+  atomic_rw_base& operator=(atomic_rw_base&&) = delete;
+
+  // some convenience functions ------------------------------------------------
+
+  T copy() const {
+    read_lock lock{mutex_};
+    return t_;
+  }
+
+  template <class... Args>
+  void assign(Args&&... args) {
+    write_lock lock{mutex_};
+    t_ = {std::forward<Args>(args)...};
+  }
+
+  // get read proxy ------------------------------------------------------------
+
+  auto operator*() const { return read_proxy_t{read_lock(mutex_), t_}; }
+  auto operator->() const { return read_proxy_t{read_lock(mutex_), t_}; }
+  auto read() const { return read_proxy_t{read_lock(mutex_), t_}; }
+
+  // get write proxy -----------------------------------------------------------
+
+  auto write() { return write_proxy_t{write_lock(mutex_), t_}; }
+
+ private:
+  mutable mutex_type mutex_;
+  T t_;
+};
+
+}  // namespace nil
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_ATOMICRWBASE_HPP_

--- a/src/async/inc/async/atomic_rw_proxy.hpp
+++ b/src/async/inc/async/atomic_rw_proxy.hpp
@@ -1,0 +1,80 @@
+#ifndef NIL_SRC_THREADSAFE_INC_THREADSAFE_ATOMICRWPROXY_HPP_
+#define NIL_SRC_THREADSAFE_INC_THREADSAFE_ATOMICRWPROXY_HPP_
+
+namespace nil {
+
+/**
+ * @note this class is returned the atomic_rw_base class and should not be used
+ * directly
+ *
+ * Captures a reader lock and a const ref to some data. Provides const-only
+ * pointer-like access to the underlying data
+ *
+ * @note assumes @tparam ReadLock is RAII and release mutex on destruction
+ * @note the instance of this class must NOT outlive the original atomic class
+ */
+template <class T, class SharedMutex, template <class> class ReadLock>
+class atomic_r_proxy {
+ public:
+  using value_type = T;
+  using mutex_type = SharedMutex;
+  using read_lock = ReadLock<SharedMutex>;
+
+  atomic_r_proxy() = delete;  //!< no default construction, must have lock
+
+  /** Takes ownership of lock */
+  atomic_r_proxy(read_lock&& lk, const T& t) : lk_{std::move(lk)}, t_{t} {}
+
+  // pointer-like access -------------------------------------------------------
+
+  const T& operator*() const { return t_; }
+  const T* operator->() const { return &t_; }
+
+  // function style access -----------------------------------------------------
+
+  const T& value() const { return t_; }
+
+ private:
+  read_lock lk_;
+  const T& t_;
+};
+
+/**
+ * Same as atomic_r_proxy, but captures its data by non-const ref, and provides
+ * non-const acccess to it.
+ *
+ * @note same as atomic_r_proxy, this should not be constructed directly
+ * @note same as atomic_r_proxy, this must NOT outlive the original atomic class
+ */
+template <class T, class SharedMutex, template <class> class WriteLock>
+class atomic_rw_proxy {
+ public:
+  using value_type = T;
+  using mutex_type = SharedMutex;
+  using write_lock = WriteLock<SharedMutex>;
+
+  atomic_rw_proxy() = delete;  //!< must be initialized with a lock and data
+
+  /** takes ownership of write lock and ref to data */
+  atomic_rw_proxy(write_lock&& lk, T& t) : lk_{std::move(lk)}, t_{t} {}
+
+  // pointer like const and non-const access to data ---------------------------
+  T& operator*() { return t_; }
+  const T& operator*() const { return t_; }
+
+  T* operator->() { return &t_; }
+  const T* operator->() const { return &t_; }
+
+  // function style const and non-const access to data -------------------------
+
+  T& value() & { return t_; }
+  const T& value() const& { return t_; }
+
+ private:
+  write_lock lk_;
+  T& t_;
+};
+
+}  // namespace nil
+
+#endif  // NIL_SRC_THREADSAFE_INC_THREADSAFE_ATOMICRWPROXY_HPP_

--- a/src/async/tests/atomic_rw_test.cpp
+++ b/src/async/tests/atomic_rw_test.cpp
@@ -1,0 +1,113 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE atomic_rw_test
+
+#include "async/atomic_rw.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <iostream>
+#include <numeric>
+#include <set>
+
+#include "async/atomic.hpp"
+#include "async/vector.hpp"
+
+using namespace nil;
+using namespace nil::async;
+
+BOOST_AUTO_TEST_CASE(ReadTest) {
+  atomic_rw<std::set<int>> async_set{1, 4, 5, 6};
+  BOOST_CHECK(async_set.copy() == (std::set<int>{1, 4, 5, 6}));
+  async_set.assign(4, 6, 7, 9);
+  BOOST_CHECK(async_set.copy() == (std::set<int>{4, 6, 7, 9}));
+
+  auto read_func_1 = [&]() {
+    for (size_t ii{0}; ii < 100; ++ii) {
+      auto read_proxy = async_set.read();
+      BOOST_CHECK_EQUAL(read_proxy->size(), 4);
+      BOOST_CHECK_EQUAL(read_proxy.value().count(4), 1u);
+      BOOST_CHECK_EQUAL((*read_proxy).count(2), 0u);
+      BOOST_CHECK(!read_proxy->empty());
+      BOOST_CHECK_EQUAL(4 + 6 + 7 + 9, std::accumulate(read_proxy->cbegin(),
+                                                       read_proxy->cend(), 0));
+    }
+  };
+
+  auto read_func_2 = [&]() {
+    for (size_t ii{0}; ii < 100; ++ii) {
+      BOOST_CHECK_EQUAL(async_set->size(), 4);
+      BOOST_CHECK_EQUAL(async_set->count(4), 1u);
+      BOOST_CHECK_EQUAL((*async_set)->count(2), 0u);
+      BOOST_CHECK(!async_set.copy().empty());
+      BOOST_CHECK_EQUAL(4 + 6 + 7 + 9, std::accumulate(async_set->cbegin(),
+                                                       async_set->cend(), 0));
+    }
+  };
+
+  auto f1 = std::async(std::launch::async, read_func_1);
+  auto f2 = std::async(std::launch::async, read_func_1);
+  auto f3 = std::async(std::launch::async, read_func_2);
+  auto f4 = std::async(std::launch::async, read_func_1);
+  auto f5 = std::async(std::launch::async, read_func_2);
+
+  f1.get();
+  f2.get();
+  f3.get();
+  f4.get();
+  f5.get();
+}
+
+BOOST_AUTO_TEST_CASE(WriteTest) {
+  atomic_rw<std::set<int>> async_set{1, 4, 5, 6};
+  const auto& const_async_set = async_set;
+  auto read_func = [&const_async_set]() {
+    for (size_t ii{0}; ii < 100; ++ii) {
+      {
+        auto read_proxy = const_async_set.read();
+        BOOST_CHECK_EQUAL(read_proxy->size(), 4);
+        BOOST_CHECK_EQUAL(read_proxy->count(4), 1u);
+        BOOST_CHECK_EQUAL(read_proxy->count(12), 0u);
+        BOOST_CHECK_EQUAL(read_proxy->count(13), 0u);
+        BOOST_CHECK_EQUAL(read_proxy->count(14), 0u);
+        BOOST_CHECK_EQUAL(read_proxy->count(15), 0u);
+        BOOST_CHECK(!read_proxy->empty());
+        BOOST_CHECK_EQUAL(
+            1 + 4 + 5 + 6,
+            std::accumulate(read_proxy->cbegin(), read_proxy->cend(), 0));
+      }
+      for (size_t ii{0}; ii < 100; ++ii) {
+        BOOST_CHECK_EQUAL(4, 4);
+      }
+    }
+  };
+
+  auto write_func = [&async_set]() {
+    for (size_t ii{0}; ii < 100; ++ii) {
+      {
+        auto write_proxy = async_set.write();
+        write_proxy->insert(12);
+        write_proxy->insert(13);
+        write_proxy->insert(14);
+        write_proxy->insert(15);
+        write_proxy->erase(12);
+        write_proxy->erase(13);
+        write_proxy->erase(14);
+        write_proxy->erase(15);
+        auto cp = *write_proxy;
+        *write_proxy = std::set<int>({1, 2, 3, 4, 5});
+        *write_proxy = cp;
+      }
+      for (size_t ii{0}; ii < 100; ++ii) {
+        BOOST_CHECK_EQUAL(4, async_set->size());
+      }
+    }
+  };
+
+  auto f1 = std::async(std::launch::async, read_func);
+  auto f2 = std::async(std::launch::async, read_func);
+  auto f3 = std::async(std::launch::async, write_func);
+
+  f1.get();
+  f2.get();
+  f3.get();
+}


### PR DESCRIPTION
_inspired by: https://github.com/LouisCharlesC/safe_

Changes:
- a reader-write atomic class whos API returns read/write proxies
  - templated on mutex and lock type, so can work with non-stl components
  - convenience alias for STL usage
  - reading through terse, pointer-like semantics. writing requires explicit func call
- `atomic_r_proxy` holds const& to some data + RAII style shared lock
  - provides read-only access through pointer-like semantics 
- `atomic_rw_proxy` holds ref to some data + RAII style unique lock
  - provides both read and write access through pointer-like semantics 