### PR TITLE
Async Container - a generic thread-safe wrapper for STL-like containers 

### DIFF
--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -41,5 +41,7 @@ function(add_boost_test test_name)
 endfunction()
 
 add_boost_test(atomic_test)
-add_boost_test(optional_test)
 add_boost_test(atomic_rw_test)
+add_boost_test(container_test)
+add_boost_test(container_traits_test)
+add_boost_test(optional_test)

--- a/src/async/inc/async/container_base.hpp
+++ b/src/async/inc/async/container_base.hpp
@@ -1,0 +1,245 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_CONTAINER_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_CONTAINER_HPP_
+
+#include "async/container_traits.hpp"
+
+namespace nil::async {
+
+/**
+ * Wraps an STL-like container and provides thread-safe only access to all
+ * functions. Uses the same names as std::vector, std::deque and std::list, for
+ * a near drop in replacement.
+ *
+ * In addition to singular operations, it also provides a generic `apply`
+ * function which can execute arbitary number of statements while a lock is
+ * acquired
+ *
+ * @note If using STL containers, it's recommeneded to use the helper aliases
+ *
+ * @note iterators are not supported, since returning references to internal
+ * data while not acquiring a lock is not thread-safe. May be extended in future
+ * with read-write proxies
+ *
+ * @note querying by reference is also not supported for the same reason as
+ * above. So at, front and back all return copies
+ *
+ * @tparam C - a fully templated STL-Like container, such as std::vector<int>.
+ * @tparam Mutex - a standard mutex type, like std::mutex
+ * @tparam LockGuard - an RAII lock type, like std::lock_guard
+ */
+template <class C, class Mutex, template <class> class LockGuard>
+class container_base {
+ public:
+  using container_type = C;
+  using value_type = typename container_type::value_type;
+  using size_type = typename container_type::size_type;
+  using mutex_type = Mutex;
+  using lock_type_t = LockGuard<Mutex>;
+
+  // traits to detect what type this container is similar to -------------------
+
+  static constexpr auto is_vector_like = is_vector_like_v<container_type>;
+  static constexpr auto is_deque_like = is_deque_like_v<container_type>;
+  static constexpr auto is_list_like = is_list_like_v<container_type>;
+
+  // constructors --------------------------------------------------------------
+
+  container_base() = default;
+
+  template <class CT>
+  using if_container_assignable = if_assignable<container_type, CT>;
+
+  template <class... Args>
+  container_base(std::in_place_t, Args&&... args) {
+    (c_.emplace_back(std::forward<Args>(args)), ...);
+  }
+
+  template <class CT = container_type, if_container_assignable<CT>* = nullptr>
+  explicit container_base(CT&& ct) {
+    c_ = std::forward<CT>(ct);
+  }
+
+  // Copy / Move ---------------------------------------------------------------
+
+  container_base(const container_base&) = delete;
+  container_base& operator=(const container_base&) = delete;
+  container_base(container_base&&) = delete;
+  container_base& operator=(container_base&&) = delete;
+
+  // Assignment ----------------------------------------------------------------
+
+  template <class CT = container_type>
+  void assign(CT&& ct) {
+    lock_type_t lock{mutex_};
+    c_ = std::forward<CT>(ct);
+  }
+
+  template <class... Args>
+  void assign(std::in_place_t, Args&&... args) {
+    lock_type_t lock{mutex_};
+    c_.clear();
+    (c_.emplace_back(std::forward<Args>(args)), ...);
+  }
+
+  // Access --------------------------------------------------------------------
+
+  std::optional<value_type> at(size_type ii) const {
+    lock_type_t lock{mutex_};
+    if (ii >= c_.size()) {
+      return std::nullopt;
+    }
+    return c_.at(ii);
+  }
+
+  std::optional<value_type> front() const {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return std::nullopt;
+    }
+    return c_.front();
+  }
+
+  std::optional<value_type> back() const {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return std::nullopt;
+    }
+    return c_.back();
+  }
+
+  // Insertion -----------------------------------------------------------------
+
+  template <class S = size_type, class V = value_type>
+  bool insert(S index, V&& v) {
+    lock_type_t lock{mutex_};
+    if (index > c_.size()) {
+      return false;
+    }
+    c_.insert(std::next(c_.begin(), index), std::forward<V>(v));
+    return true;
+  }
+
+  template <class V = value_type>
+  void push_back(V&& v) {
+    lock_type_t lock{mutex_};
+    return c_.push_back(std::forward<V>(v));
+  }
+
+  template <class V = value_type>
+  void push_front(V&& v) {
+    lock_type_t lock{mutex_};
+    return c_.push_front(std::forward<V>(v));
+  }
+
+  // Remove --------------------------------------------------------------------
+
+  void clear() {
+    lock_type_t lock{mutex_};
+    c_.clear();
+  }
+
+  void erase(size_type ii) {
+    lock_type_t lock{mutex_};
+    if (ii >= c_.size()) {
+      return;
+    }
+    c_.erase(std::next(c_.begin(), ii));
+  }
+
+  void pop_back() {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return;
+    }
+    c_.pop_back();
+  }
+
+  void pop_front() {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return;
+    }
+    c_.pop_front();
+  }
+
+  std::optional<value_type> extract(size_type ii) {
+    lock_type_t lock{mutex_};
+    if (ii >= c_.size()) {
+      return std::nullopt;
+    }
+    auto v = std::move(c_.at(ii));
+    c_.erase(std::next(c_.begin(), ii));
+    return std::move(v);
+  }
+
+  std::optional<value_type> extract_back() {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return std::nullopt;
+    }
+    auto v = std::move(c_.back());
+    c_.pop_back();
+    return std::move(v);
+  }
+
+  std::optional<value_type> extract_front() {
+    lock_type_t lock{mutex_};
+    if (c_.empty()) {
+      return std::nullopt;
+    }
+    auto v = std::move(c_.front());
+    c_.pop_front();
+    return std::move(v);
+  }
+
+  // arbitrary function --------------------------------------------------------
+
+  template <class F, class = if_invocable<F, const container_type&>>
+  auto apply(F&& f) const {
+    lock_type_t lock{mutex_};
+    return std::invoke(std::forward<F>(f), c_);
+  }
+
+  template <class F, class = if_invocable<F, container_type&>>
+  auto apply(F&& f) {
+    lock_type_t lock{mutex_};
+    return std::invoke(std::forward<F>(f), c_);
+  }
+
+  template <class F, class = if_invocable<F, const value_type&>>
+  void apply_each(F&& f) const {
+    lock_type_t lock{mutex_};
+    for (const auto& ii : c_) {
+      std::invoke(std::forward<F>(f), ii);
+    }
+  }
+
+  template <class F, class = If<std::is_invocable_v<F, value_type&> &&
+                                not std::is_invocable_v<F, const value_type&>>>
+  void apply_each(F&& f) {
+    lock_type_t lock{mutex_};
+    for (auto& ii : c_) {
+      std::invoke(std::forward<F>(f), ii);
+    }
+  }
+
+  // state observers -----------------------------------------------------------
+
+  size_type size() const noexcept {
+    lock_type_t lock{mutex_};
+    return c_.size();
+  }
+
+  bool empty() const noexcept {
+    lock_type_t lock{mutex_};
+    return c_.empty();
+  }
+
+ private:
+  mutable mutex_type mutex_;
+  container_type c_;
+};
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_CONTAINER_HPP_

--- a/src/async/inc/async/container_traits.hpp
+++ b/src/async/inc/async/container_traits.hpp
@@ -1,0 +1,140 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_CONTAINERTRAITS_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_CONTAINERTRAITS_HPP_
+
+#include <meta/enable_if.hpp>
+
+namespace nil::async {
+
+template <class T, class S>
+using at_func = decltype(std::declval<const T>().at(std::declval<S>()));
+
+template <class T>
+using front_func = decltype(std::declval<const T>().front());
+
+template <class T>
+using back_func = decltype(std::declval<const T>().back());
+
+template <class T>
+using top_func = decltype(std::declval<const T>().top());
+
+template <class T, class V>
+using push_func = decltype(std::declval<T>().push(std::declval<V>()));
+
+template <class T, class V>
+using push_back_func = decltype(std::declval<T>().push_back(std::declval<V>()));
+
+template <class T, class V>
+using push_front_func =
+    decltype(std::declval<T>().push_front(std::declval<V>()));
+
+template <class T, class... Args>
+using emplace_back_func =
+    decltype(std::declval<T>().emplace_back(std::declval<Args>()...));
+
+template <class T, class... Args>
+using emplace_front_func =
+    decltype(std::declval<T>().emplace_front(std::declval<Args>()...));
+
+template <class T>
+using pop_func = decltype(std::declval<T>().pop());
+
+template <class T>
+using pop_back_func = decltype(std::declval<T>().pop_back());
+
+template <class T>
+using pop_front_func = decltype(std::declval<T>().pop_front());
+
+template <class T, class I, class V>
+using insert_func =
+    decltype(std::declval<T>().insert(std::declval<I>(), std::declval<V>()));
+
+template <class T, class I>
+using erase_func = decltype(std::declval<T>().erase(std::declval<I>()));
+
+template <class T>
+using clear_func = decltype(std::declval<T>().clear());
+
+template <class T>
+using size_func = decltype(std::declval<const T>().size());
+
+template <class T>
+using empty_func = decltype(std::declval<const T>().empty());
+
+// -----------------------------------------------------------------------------
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+using is_vector_like = std::conjunction<  //
+    exists_similar<V, at_func, T, S>,     //
+    exists_similar<V, front_func, T>,     //
+    exists_similar<V, back_func, T>,      //
+    exists<push_back_func, T, V>,         //
+    exists<emplace_back_func, T, V>,      //
+    exists<pop_back_func, T>,             //
+    exists<insert_func, T, I, V>,         //
+    exists<erase_func, T, I>,             //
+    is_exact<S, size_func, T>,            //
+    is_exact<bool, empty_func, T>,        //
+    exists<clear_func, T>>;
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+inline constexpr auto is_vector_like_v = is_vector_like<T, V, S, I>::value;
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+using is_deque_like = std::conjunction<  //
+    exists_similar<V, at_func, T, S>,    //
+    exists_similar<V, front_func, T>,    //
+    exists_similar<V, back_func, T>,     //
+    exists<push_back_func, T, V>,        //
+    exists<push_front_func, T, V>,       //
+    exists<emplace_back_func, T, V>,     //
+    exists<emplace_front_func, T, V>,    //
+    exists<pop_back_func, T>,            //
+    exists<pop_front_func, T>,           //
+    exists<insert_func, T, I, V>,        //
+    exists<erase_func, T, I>,            //
+    is_exact<S, size_func, T>,           //
+    is_exact<bool, empty_func, T>,       //
+    exists<clear_func, T>>;
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+inline constexpr auto is_deque_like_v = is_deque_like<T, V, S, I>::value;
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+using is_list_like = std::conjunction<exists_similar<V, front_func, T>,  //
+                                      exists_similar<V, back_func, T>,   //
+                                      exists<push_back_func, T, V>,      //
+                                      exists<push_front_func, T, V>,     //
+                                      exists<emplace_back_func, T, V>,   //
+                                      exists<emplace_front_func, T, V>,  //
+                                      exists<pop_back_func, T>,          //
+                                      exists<pop_back_func, T>,          //
+                                      exists<insert_func, T, I, V>,      //
+                                      exists<erase_func, T, I>,          //
+                                      is_exact<S, size_func, T>,         //
+                                      is_exact<bool, empty_func, T>,     //
+                                      exists<clear_func, T>>;
+
+template <class T,                           //
+          class V = typename T::value_type,  //
+          class S = typename T::size_type,   //
+          class I = typename T::iterator>
+inline constexpr auto is_list_like_v = is_list_like<T, V, S, I>::value;
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_CONTAINERTRAITS_HPP_

--- a/src/async/inc/async/deque.hpp
+++ b/src/async/inc/async/deque.hpp
@@ -1,0 +1,21 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_DEQUE_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_DEQUE_HPP_
+
+#include <deque>
+#include <mutex>
+
+#include "async/container_base.hpp"
+
+namespace nil::async {
+
+/**
+ * Partially specified alias when using container_base with std::deque,
+ * std::mutex and std::lock_guard. Prefer this over container base for deques
+ */
+template <class T, class... Params>
+using deque =
+    container_base<std::deque<T, Params...>, std::mutex, std::lock_guard>;
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_DEQUE_HPP_

--- a/src/async/inc/async/list.hpp
+++ b/src/async/inc/async/list.hpp
@@ -1,0 +1,21 @@
+#ifndef NIL_SRC_THREADSAFE_INC_THREADSAFE_LIST_HPP_
+#define NIL_SRC_THREADSAFE_INC_THREADSAFE_LIST_HPP_
+
+#include <list>
+#include <mutex>
+
+#include "async/container_base.hpp"
+
+namespace nil::async {
+
+/**
+ * Partially specified alias when using container_base with std::list,
+ * std::mutex and std::lock_guard. Prefer this over container_base for list
+ */
+template <class T, class... Params>
+using list =
+    container_base<std::list<T, Params...>, std::mutex, std::lock_guard>;
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_THREADSAFE_INC_THREADSAFE_LIST_HPP_

--- a/src/async/inc/async/vector.hpp
+++ b/src/async/inc/async/vector.hpp
@@ -1,0 +1,21 @@
+#ifndef NIL_SRC_ASYNC_INC_ASYNC_VECTOR_HPP_
+#define NIL_SRC_ASYNC_INC_ASYNC_VECTOR_HPP_
+
+#include <mutex>
+#include <vector>
+
+#include "async/container_base.hpp"
+
+namespace nil::async {
+
+/**
+ * Partially specified alias when using container_base with std::vector,
+ * std::mutex and std::lock_guard. Prefer this over container_base for vectors
+ */
+template <class T, class... Params>
+using vector =
+    container_base<std::vector<T, Params...>, std::mutex, std::lock_guard>;
+
+}  // namespace nil::async
+
+#endif  // NIL_SRC_ASYNC_INC_ASYNC_VECTOR_HPP_

--- a/src/async/tests/container_test.cpp
+++ b/src/async/tests/container_test.cpp
@@ -1,0 +1,306 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE container_test
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <meta/none_such.hpp>
+#include <numeric>
+
+#include "async/deque.hpp"
+#include "async/list.hpp"
+#include "async/vector.hpp"
+
+using namespace nil;
+using namespace nil::async;
+
+template <class CT, class V = typename CT::value_type>
+void VerifyAt(const CT& c, const V& front, const V& back, const size_t& size,
+              const typename CT::container_type& elements) {
+  BOOST_CHECK_EQUAL(size, c.size());
+
+  if (size == 0) {
+    BOOST_CHECK(c.empty());
+  } else {
+    BOOST_CHECK_EQUAL(front, c.front().value());
+    BOOST_CHECK_EQUAL(back, c.back().value());
+    BOOST_CHECK(!c.empty());
+  }
+
+  if constexpr (CT::is_vector_like || CT::is_deque_like) {
+    for (size_t ii{0}; ii < size; ii++) {
+      BOOST_CHECK_EQUAL(elements.at(ii), c.at(ii).value());
+    }
+  }
+}
+
+template <class CT>
+void VerifySize(const CT& c, typename CT::size_type expected_size) {
+  BOOST_CHECK_EQUAL(c.size(), expected_size);
+  BOOST_CHECK_EQUAL(c.empty(), (expected_size == 0));
+}
+
+using IntTypes = boost::mpl::list<vector<int>, deque<int>, list<int>>;
+using StrTypes = boost::mpl::list<vector<std::string>, deque<std::string>,
+                                  list<std::string>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ConstructAssignTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec;  // default construct
+  VerifySize(async_vec, 0);
+
+  async_vec.assign(container_type{"1", "2", "4"});
+  VerifySize(async_vec, 3);
+
+  async_vec.assign({"1", "9", "4", "7"});
+  VerifySize(async_vec, 4);
+
+  async_vec.assign(std::in_place, "7", "4");
+  VerifySize(async_vec, 2);
+
+  async_vec.clear();
+  VerifySize(async_vec, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(AtTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec;
+  VerifyAt(async_vec, {}, {}, 0, {});
+
+  async_vec.push_back("1");
+  VerifyAt(async_vec, "1", "1", 1, {"1"});
+
+  if constexpr (CT::is_vector_like || CT::is_deque_like) {
+    auto elem_0_copy = async_vec.at(0).value();
+    elem_0_copy = "2";  // shouldn't modify original
+    VerifyAt(async_vec, "1", "1", 1, {"1"});
+  }
+
+  async_vec.clear();
+  VerifyAt(async_vec, {}, {}, 0, {});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(PushPopBackTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec;
+  VerifySize(async_vec, 0);
+
+  async_vec.push_back("3");
+  async_vec.push_back("4");
+  async_vec.push_back("5");
+  VerifyAt(async_vec, "3", "5", 3, {"3", "4", "5"});
+
+  async_vec.pop_back();
+  async_vec.pop_back();
+  VerifyAt(async_vec, "3", "3", 1, {"3"});
+
+  if constexpr (CT::is_deque_like || CT::is_list_like) {
+    async_vec.push_front("1");
+    async_vec.push_front("2");
+    async_vec.push_front("7");
+    async_vec.pop_front();
+    VerifyAt(async_vec, "2", "3", 3, {"2", "1", "3"});
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ExtractTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec{std::in_place, "1", "2", "3"};
+  VerifySize(async_vec, 3);
+
+  if constexpr (CT::is_vector_like || CT::is_deque_like) {
+    auto str_opt = async_vec.extract(0);
+    BOOST_CHECK(str_opt != std::nullopt);
+    BOOST_CHECK(str_opt.value() == "1");
+    VerifyAt(async_vec, "2", "3", 2, {"2", "3"});
+  }
+  async_vec.assign(std::in_place, "2", "3");
+
+  auto str_opt = async_vec.extract_back();
+  BOOST_CHECK(str_opt != std::nullopt);
+  BOOST_CHECK(str_opt.value() == "3");
+  VerifyAt(async_vec, "2", "2", 1, {"2"});
+
+  if constexpr (CT::is_vector_like || CT::is_deque_like) {
+    auto str_opt = async_vec.extract(0);
+    BOOST_CHECK(str_opt != std::nullopt);
+    BOOST_CHECK(str_opt.value() == "2");
+    VerifyAt(async_vec, {}, {}, 0, {});
+    str_opt = async_vec.extract(0);
+    BOOST_CHECK(str_opt == std::nullopt);
+  }
+  async_vec.clear();
+  str_opt = async_vec.extract_back();
+  BOOST_CHECK(str_opt == std::nullopt);
+
+  if constexpr (CT::is_deque_like || CT::is_list_like) {
+    async_vec.assign(std::in_place, "1", "2", "3");
+    auto str_opt = async_vec.extract_front();
+    BOOST_CHECK(str_opt != std::nullopt);
+    BOOST_CHECK(str_opt.value() == "1");
+    VerifyAt(async_vec, "2", "3", 2, {"2", "3"});
+    async_vec.clear();
+    str_opt = async_vec.extract_front();
+    BOOST_CHECK(str_opt == std::nullopt);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EraseTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec{std::in_place, "1", "2", "3"};
+
+  async_vec.erase(1);
+  VerifyAt(async_vec, "1", "3", 2, {"1", "3"});
+
+  async_vec.erase(1);
+  VerifyAt(async_vec, "1", "1", 1, {"1"});
+
+  async_vec.erase(1);
+  VerifyAt(async_vec, "1", "1", 1, {"1"});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ApplyTest, CT, StrTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec{std::in_place, "1", "2", "3"};
+
+  const auto& const_async_vec = async_vec;
+  auto size =
+      const_async_vec.apply([](const container_type& c) { return c.size(); });
+  BOOST_CHECK(size == const_async_vec.size());
+
+  async_vec.pop_back();
+  const_async_vec.apply([&size](const container_type& c) { size = c.size(); });
+  BOOST_CHECK(size == const_async_vec.size());
+
+  auto ret = async_vec.apply([](container_type& c) {
+    c.push_back("4");
+    return 5;
+  });
+  BOOST_CHECK_EQUAL("4", async_vec.back().value());
+  BOOST_CHECK_EQUAL(5, ret);
+
+  size = 0;
+  const_async_vec.apply_each([&size](const auto&) { size++; });
+  BOOST_CHECK_EQUAL(size, const_async_vec.size());
+
+  async_vec.apply_each([](std::string& v) { v = "0"; });
+  auto non_async_c = async_vec.apply([](const auto& c) { return c; });
+  for (const auto& ii : non_async_c) {
+    BOOST_CHECK_EQUAL(ii, "0");
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(PushExtractMultithreadTest, CT, IntTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec;
+
+  const auto num_elements = 10000;
+
+  container_type c_in;
+  int total = 0;
+  for (size_t ii{0}; ii < num_elements; ii++) {
+    c_in.push_back(ii);
+    total += ii;
+  }
+
+  container_type c_out;
+
+  auto f1 = std::async(std::launch::async, [&]() {
+    for (const auto& ii : c_in) {
+      async_vec.push_back(ii);
+    }
+  });
+
+  auto f2 = std::async(std::launch::async, [&]() {
+    while (c_out.size() != num_elements) {
+      auto opt = async_vec.extract_back();
+      if (opt != std::nullopt) {
+        c_out.push_back(opt.value());
+      }
+    }
+  });
+
+  auto f3 = std::async(std::launch::async, [&]() -> bool {
+    while (f2.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+      if constexpr (CT::is_vector_like || CT::is_deque_like) {
+        if (async_vec.at(0).value_or(0) >= num_elements) {
+          return false;
+        }
+      }
+      if (async_vec.front().value_or(0) >= num_elements) {
+        return false;
+      }
+      if (async_vec.back().value_or(0) >= num_elements) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  f1.get();
+  f2.get();
+  BOOST_CHECK(f3.get());
+  BOOST_CHECK_EQUAL(c_in.size(), c_out.size());
+  BOOST_CHECK_EQUAL(total, std::accumulate(c_out.cbegin(), c_out.cend(), 0));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ApplyMultiThreadTest, CT, IntTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec{std::in_place, 0, 10, 100};
+  auto func = [&]() {
+    for (size_t ii{0}; ii < 1000; ii++) {
+      async_vec.apply_each([](int& ii) { ii++; });
+    }
+  };
+
+  std::vector<std::future<void>> v_f;
+  for (size_t ii{0}; ii < 10; ii++) {
+    v_f.push_back(std::async(std::launch::async, func));
+  }
+
+  for (auto& f : v_f) {
+    f.get();
+  }
+
+  BOOST_CHECK_EQUAL(1000 * 10 + 100, async_vec.extract_back().value());
+  BOOST_CHECK_EQUAL(1000 * 10 + 10, async_vec.extract_back().value());
+  BOOST_CHECK_EQUAL(1000 * 10, async_vec.extract_back().value());
+}
+
+using MoveOnlyTypes =
+    boost::mpl::list<vector<MoveOnly>, deque<MoveOnly>, list<MoveOnly>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(MoveOnlyTypeTest, CT, MoveOnlyTypes) {
+  using container_type = typename CT::container_type;
+  CT async_vec{std::in_place, MoveOnly{}, MoveOnly{}, MoveOnly{}};
+  VerifySize(async_vec, 3);
+
+  auto move_only_opt = async_vec.extract_back();
+  BOOST_CHECK(move_only_opt != std::nullopt);
+  VerifySize(async_vec, 2);
+
+  move_only_opt = [&]() {
+    if constexpr (CT::is_vector_like) {
+      return async_vec.extract(0);
+    } else {
+      return async_vec.extract_front();
+    }
+  }();
+
+  BOOST_CHECK(move_only_opt != std::nullopt);
+  VerifySize(async_vec, 1);
+
+  async_vec.push_back(MoveOnly{});
+  VerifySize(async_vec, 2);
+
+  async_vec.push_back({});
+  VerifySize(async_vec, 3);
+
+  async_vec.assign(std::in_place, MoveOnly{}, MoveOnly{});
+  VerifySize(async_vec, 2);
+
+  container_type underlying;
+  underlying.emplace_back(MoveOnly{});
+  async_vec.assign(std::move(underlying));
+  VerifySize(async_vec, 1);
+}

--- a/src/async/tests/container_traits_test.cpp
+++ b/src/async/tests/container_traits_test.cpp
@@ -1,0 +1,156 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE container_traits_test
+
+#include "async/container_traits.hpp"
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+#include <mutex>
+
+#include "async/container_base.hpp"
+
+using namespace nil;
+using namespace nil::async;
+
+template <class T>
+struct VectorLike {
+  using value_type = T;
+  using size_type = int;
+  using iterator = int;
+  VectorLike() = default;
+
+  value_type at(size_type ii) const { return value_type{}; }
+  value_type front() const { return value_type{}; }
+  value_type back() const { return value_type{}; }
+
+  void insert(iterator, const value_type&) {}
+  void push_back(const value_type&) {}
+  void pop_back() {}
+
+  template <class... Args>
+  void emplace_back(Args&&...) {}
+
+  size_type size() const { return size_type{}; }
+  bool empty() const { return true; }
+  void clear() {}
+  void erase(iterator) {}
+};
+
+template <class T>
+struct DequeLike {
+  using value_type = T;
+  using size_type = int;
+  using iterator = int;
+  DequeLike() = default;
+
+  value_type at(size_type ii) const { return value_type{}; }
+  value_type front() const { return value_type{}; }
+  value_type back() const { return value_type{}; }
+
+  void insert(iterator, const value_type&) {}
+  void push_back(const value_type&) {}
+  void push_front(const value_type&) {}
+  void pop_back() {}
+  void pop_front() {}
+
+  template <class... Args>
+  void emplace_back(Args&&...) {}
+
+  template <class... Args>
+  void emplace_front(Args&&...) {}
+
+  size_type size() const { return size_type{}; }
+  bool empty() const { return true; }
+  void clear() {}
+  void erase(iterator) {}
+};
+
+template <class T>
+struct ListLike {
+  using value_type = T;
+  using size_type = int;
+  using iterator = int;
+  ListLike() = default;
+
+  value_type front() const { return value_type{}; }
+  value_type back() const { return value_type{}; }
+
+  void insert(iterator, const value_type&) {}
+  void push_back(const value_type&) {}
+  void push_front(const value_type&) {}
+  void pop_back() {}
+  void pop_front() {}
+
+  template <class... Args>
+  void emplace_back(Args&&...) {}
+
+  template <class... Args>
+  void emplace_front(Args&&...) {}
+
+  size_type size() const { return size_type{}; }
+  bool empty() const { return true; }
+  void clear() const {}
+  void erase(size_type ii) {}
+};
+
+using VectorTypes = boost::mpl::list<int, std::string, size_t, MoveOnly>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(VectorTraitTest, T, VectorTypes) {
+  using CT = async::container_base<VectorLike<T>, std::mutex, std::lock_guard>;
+  using C = typename CT::container_type;
+  using V = typename C::value_type;
+  using S = typename C::size_type;
+  using I = typename C::iterator;
+
+  BOOST_CHECK(CT::is_vector_like);
+  BOOST_CHECK((is_vector_like_v<C>));
+  BOOST_CHECK((is_vector_like_v<C, V, S, I>));
+
+  BOOST_CHECK(!CT::is_deque_like);
+  BOOST_CHECK((!is_deque_like_v<C>));
+  BOOST_CHECK((!is_deque_like_v<C, V, S, I>));
+
+  BOOST_CHECK(!CT::is_list_like);
+  BOOST_CHECK((!is_list_like_v<C>));
+  BOOST_CHECK((!is_list_like_v<C, V, S, I>));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(DequeTraitTest, T, VectorTypes) {
+  using CT = async::container_base<DequeLike<T>, std::mutex, std::lock_guard>;
+  using C = typename CT::container_type;
+  using V = typename C::value_type;
+  using S = typename C::size_type;
+  using I = typename C::iterator;
+
+  BOOST_CHECK(CT::is_vector_like);
+  BOOST_CHECK((is_vector_like_v<C>));
+  BOOST_CHECK((is_vector_like_v<C, V, S, I>));
+
+  BOOST_CHECK(CT::is_deque_like);
+  BOOST_CHECK((is_deque_like_v<C>));
+  BOOST_CHECK((is_deque_like_v<C, V, S, I>));
+
+  BOOST_CHECK(CT::is_list_like);
+  BOOST_CHECK((is_list_like_v<C>));
+  BOOST_CHECK((is_list_like_v<C, V, S, I>));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ListTraitTest, T, VectorTypes) {
+  using CT = async::container_base<ListLike<T>, std::mutex, std::lock_guard>;
+  using C = typename CT::container_type;
+  using V = typename C::value_type;
+  using S = typename C::size_type;
+  using I = typename C::iterator;
+
+  BOOST_CHECK(!CT::is_vector_like);
+  BOOST_CHECK((!is_vector_like_v<C>));
+  BOOST_CHECK((!is_vector_like_v<C, V, S, I>));
+
+  BOOST_CHECK(!CT::is_deque_like);
+  BOOST_CHECK((!is_deque_like_v<C>));
+  BOOST_CHECK((!is_deque_like_v<C, V, S, I>));
+
+  BOOST_CHECK(CT::is_list_like);
+  BOOST_CHECK((is_list_like_v<C>));
+  BOOST_CHECK((is_list_like_v<C, V, S, I>));
+}


### PR DESCRIPTION
Changes:
- `async::container_base` provides threadsafe only access to some type
  - implements various STL-container-like functions, such as push[back][front], at, front, back, emplace[front][back], size, empty, etc.
  - templated type isn't required to provide all functions as long as they are not used (fails to compile if attempted)
  - convenience aliases for working with std::vector, std::deque and std::list
  - also templated on mutex / lock type to use
  - doesn't provide access to reference producing function calls, since those would not be thread-safe. Some funcs that returned refs now return copies. 